### PR TITLE
Nginx reload

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -142,7 +142,7 @@
         "actions": {
             "setupNode": [{
                 "cmd[${this.filter}]": [
-                    "/etc/init.d/nginx restart"
+                    "/etc/init.d/nginx reload"
                 ]
             }, {
                 "cmd[bl]": [


### PR DESCRIPTION
After load testing, we get some error 500 during the restart of the nginx nodes. So if we reload, everything works fine without error.